### PR TITLE
Add gt2n (2nm) analytical bitcell/timing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,19 @@ assumed to be vertical. This means that signal pins will be on metal 4 and the
 supply straps (also on metal 4) will be horizontal. If set to true then metal 1
 is assumed to be horizontal. This means that signal pins will be on metal 3 and
 the supply straps (on metal 4) will be vertical. By default, `flipPins = false`.
+`flipPins` continues to govern the supply-strap orientation even when
+`LRpinLayer`/`TBpinLayer`/`PSpinLayer` are used to override the signal/supply
+pin layers below — the two are independent knobs, so overriding the layers
+does not change strap direction, and the pair must be kept mutually
+consistent by hand.
+
+`LRpinLayer` / `TBpinLayer` / `PSpinLayer` ***(Optional)*** - Explicit metal
+layer name (e.g. `"M2"`) for the **left/right** signal pins, **top/bottom**
+signal pins, and supply (VDD/VSS) straps, respectively. Overrides the layer
+that would otherwise be derived from `flipPins`. Use this for platforms whose
+pin layers can't be expressed by the `flipPins` heuristic alone (e.g. a
+process that puts L/R pins on M2 and T/B pins on M3). Unset by default, in
+which case the `flipPins`-derived layer is used.
 
 `srams` - A list of SRAMs to generate. Each sram should have: 
 - `name` - the name associated with the sram config in the SRAM's `.lef`, `.lib`, and `.v` files

--- a/example_cfgs/gt2n.cfg
+++ b/example_cfgs/gt2n.cfg
@@ -1,0 +1,57 @@
+{
+  # The process node.
+  "tech_nm": 2,
+
+  # The operating voltage.
+  "voltage": 0.7,
+
+  # String to add in front of every metal layer number for the layer name.
+  "metalPrefix": "M",
+
+  # Define pin geometries for left/right and top/bottom
+  "LRpinWidth_nm": 12,
+  "LRpinPitch_nm": 24,
+  "TBpinWidth_nm": 14,
+  "TBpinPitch_nm": 28,
+
+  # gt2n's L/R and T/B pin layers can't be derived from the flipPins
+  # heuristic, so they're set explicitly.
+  "LRpinLayer": "M2",
+  "TBpinLayer": "M3",
+
+  # Flip Pins = false for M4, true for M3. flipPins still governs the
+  # supply-strap orientation even with the pin-layer overrides above.
+  "flipPins": false,
+
+  # Optional snap the width and height of the sram to a multiple value.
+  "snapWidth_nm":  42,
+  "snapHeight_nm": 144,
+
+  # List of SRAM configurations (name width depth and banks)
+  "srams": [
+    {
+     "name": "fakeram_1x256_1r1w",
+     "width": 1,
+     "depth": 256,
+     "banks": 1,
+     "no_wmask": "true",
+     "ports": {
+       "r": 1,
+       "w": 1,
+       "rw": 0
+     }
+    },
+    {
+     "name": "fakeram_32x128_2r1w",
+     "width": 32,
+     "depth": 128,
+     "banks": 1,
+     "no_wmask": "true",
+     "ports": {
+       "r": 2,
+       "w": 1,
+       "rw": 0
+     }
+    }
+  ]
+}

--- a/scripts/utils/area.py
+++ b/scripts/utils/area.py
@@ -10,26 +10,25 @@ import math
 #              10 fin-pitches; 0.0292 um^2 bitcell).
 #  - sky130hd: 1.070 x 1.740 um — published bitcell from the
 #              skywater-pdk OpenRAM 6T SRAM (~1.86 um^2 bitcell).
-#  - gt2n     : 0.0917 x 0.2291 um (~0.021 um^2) — the previous value (1 site width x
-#              1 site height, ~0.0060 um^2) was an unvalidated placeholder cross-checked
-#              only against an unrelated non-SRAM design's (floonoc) overall die-area
-#              scaling ratio, not any real device data. Replaced with TSMC's own
-#              disclosed 2nm-class (N2) high-density SRAM bitcell area (~0.021 um^2,
-#              "A 38.1Mb/mm2 SRAM in a 2nm-CMOS-Nanosheet Technology",
-#              research.tsmc.com/page/memory/4.html; no published W x H breakdown found
-#              for that figure, so the area alone is the sourced quantity). Split at a
-#              2.5 height:width aspect matching asap7's real bitcell aspect (0.270/0.108
-#              = 2.5), not sky130hd's (1.626) — asap7 is a FinFET predictive PDK, a much
-#              closer device-architecture analog to gt2n's GAAFET nanosheet transistors
-#              than sky130hd's 130nm planar bulk process, even though neither is a
-#              literal GAA measurement. Reflects the real "SRAM scaling wall" — SRAM
-#              bitcell area has scaled far slower than logic across process nodes, so a
-#              device-realistic macro is *larger* relative to gt2n's very fine row pitch
-#              than the old placeholder assumed, not smaller.
+#  - gt2n    : 0.0917 x 0.2291 um (~0.021 um^2) — TSMC's disclosed 2nm-class
+#              (N2) high-density SRAM bitcell area ("A 38.1Mb/mm2 SRAM in a
+#              2nm-CMOS-Nanosheet Technology", research.tsmc.com/page/
+#              memory/4.html; no published W x H breakdown for that figure,
+#              so the area alone is the sourced quantity). Split at a 2.5
+#              height:width aspect matching asap7's real bitcell aspect
+#              (0.270/0.108 = 2.5), not sky130hd's (1.626) — asap7 is a
+#              FinFET predictive PDK, a much closer device-architecture
+#              analog to gt2n's GAAFET nanosheet transistors than
+#              sky130hd's 130nm planar bulk process, even though neither is
+#              a literal GAA measurement. Reflects the real "SRAM scaling
+#              wall": SRAM bitcell area scales far slower than logic across
+#              process nodes, so gt2n's bitcell is much larger relative to
+#              its very fine row pitch than a naive logic-scaled estimate
+#              would give.
 TECH_BITCELL_UM = {
+    2:   (0.0917, 0.2291),
     7:   (0.108, 0.270),
     130: (1.070, 1.740),
-    2:   (0.0917, 0.2291),
 }
 
 # Total SRAM area = bitcell_array * PERIPHERY_MULT_PER_DIM in each

--- a/scripts/utils/area.py
+++ b/scripts/utils/area.py
@@ -10,9 +10,26 @@ import math
 #              10 fin-pitches; 0.0292 um^2 bitcell).
 #  - sky130hd: 1.070 x 1.740 um — published bitcell from the
 #              skywater-pdk OpenRAM 6T SRAM (~1.86 um^2 bitcell).
+#  - gt2n     : 0.0917 x 0.2291 um (~0.021 um^2) — the previous value (1 site width x
+#              1 site height, ~0.0060 um^2) was an unvalidated placeholder cross-checked
+#              only against an unrelated non-SRAM design's (floonoc) overall die-area
+#              scaling ratio, not any real device data. Replaced with TSMC's own
+#              disclosed 2nm-class (N2) high-density SRAM bitcell area (~0.021 um^2,
+#              "A 38.1Mb/mm2 SRAM in a 2nm-CMOS-Nanosheet Technology",
+#              research.tsmc.com/page/memory/4.html; no published W x H breakdown found
+#              for that figure, so the area alone is the sourced quantity). Split at a
+#              2.5 height:width aspect matching asap7's real bitcell aspect (0.270/0.108
+#              = 2.5), not sky130hd's (1.626) — asap7 is a FinFET predictive PDK, a much
+#              closer device-architecture analog to gt2n's GAAFET nanosheet transistors
+#              than sky130hd's 130nm planar bulk process, even though neither is a
+#              literal GAA measurement. Reflects the real "SRAM scaling wall" — SRAM
+#              bitcell area has scaled far slower than logic across process nodes, so a
+#              device-realistic macro is *larger* relative to gt2n's very fine row pitch
+#              than the old placeholder assumed, not smaller.
 TECH_BITCELL_UM = {
     7:   (0.108, 0.270),
     130: (1.070, 1.740),
+    2:   (0.0917, 0.2291),
 }
 
 # Total SRAM area = bitcell_array * PERIPHERY_MULT_PER_DIM in each

--- a/scripts/utils/class_memory.py
+++ b/scripts/utils/class_memory.py
@@ -81,6 +81,22 @@ class Memory:
         standby_leakage_per_bank_mW=0.05, fo4_ps=200.0,
         pin_dynamic_power_mW=0.015,
       ),
+      # gt2n (2nm GAAFET): faster than asap7 (FO4 ~5 ps vs 9 ps).
+      # access_time_ns corrected 2026-08-01: previously 0.10ns, scaled from
+      # sky130hd by FO4 logic-switching ratio (1.4ns / 14x). That anchor was
+      # wrong -- bitline/sense-amp access time is bitcell/array-dominated, not
+      # logic-gate-switching-dominated, so it doesn't scale with FO4 the way
+      # a logic path does (the "SRAM scaling wall": memory timing scales much
+      # slower across nodes than logic speed). Re-anchored to asap7's own
+      # measured 0.2183ns instead -- gt2n and asap7 are both leading-edge
+      # finFET/GAAFET nodes with comparable bitcell physics, so gt2n's access
+      # time should be close to, not a further-scaled-down multiple of,
+      # asap7's. All other values still order-of-magnitude estimates.
+      2: dict(
+        access_time_ns=0.200, cycle_time_ns=0.075,
+        standby_leakage_per_bank_mW=0.10, fo4_ps=5.0,
+        pin_dynamic_power_mW=0.001,
+      ),
     }
     if process.tech_nm in TECH_ANALYTIC:
       self.tech_node_nm  = process.tech_nm

--- a/scripts/utils/class_memory.py
+++ b/scripts/utils/class_memory.py
@@ -4,7 +4,7 @@ import os
 import sys
 from pathlib import Path
 from utils.cacti_config import cacti_config
-from utils.area import get_macro_dimensions
+from utils.area import get_macro_dimensions, TECH_BITCELL_UM
 ################################################################################
 # MEMORY CLASS
 #
@@ -71,6 +71,25 @@ class Memory:
     # standby per bank, ~200 ps FO4, ~0.015 mW per pin). Adjust if real
     # silicon measurements become available.
     TECH_ANALYTIC = {
+      # gt2n (2nm GAAFET): faster than asap7 (FO4 ~5 ps vs 9 ps), but
+      # access_time_ns and cycle_time_ns are anchored to asap7's own
+      # measured values (0.2183ns / 0.1566ns) rather than scaled by the
+      # FO4 ratio -- bitline/sense-amp timing is bitcell/array-dominated,
+      # not logic-gate-switching-dominated, so it doesn't scale with FO4
+      # the way a logic path does (the "SRAM scaling wall": memory timing
+      # scales much slower across nodes than logic speed). gt2n and asap7
+      # are both leading-edge finFET/GAAFET nodes with comparable bitcell
+      # physics, so gt2n's access/cycle time should be close to asap7's,
+      # not a further FO4-scaled-down multiple of it; cycle_time_ns holds
+      # the same ~0.72 cycle/access ratio asap7 and sky130hd both show.
+      2: dict(
+        access_time_ns=0.200,  # asap7's 0.2183 * ~90%
+        cycle_time_ns=0.1435,  # access_time_ns * asap7/sky130hd's ~0.72 cycle/access ratio
+        standby_leakage_per_bank_mW=0.10, fo4_ps=5.0,
+        pin_dynamic_power_mW=0.001,
+        cap_input_pf=0.000488,  # gt2_6t_buf_x1_w31_lvt input cap (real GT2N PDK min-driver cell)
+        t_setup_ns=0.007, t_hold_ns=0.007,  # gt2_6t_dffasync_x1_w31_lvt D-vs-CLK, nominal-slew corner
+      ),
       7: dict(
         access_time_ns=0.2183, cycle_time_ns=0.1566,
         standby_leakage_per_bank_mW=0.1289, fo4_ps=9.0632,
@@ -81,24 +100,14 @@ class Memory:
         standby_leakage_per_bank_mW=0.05, fo4_ps=200.0,
         pin_dynamic_power_mW=0.015,
       ),
-      # gt2n (2nm GAAFET): faster than asap7 (FO4 ~5 ps vs 9 ps).
-      # access_time_ns corrected 2026-08-01: previously 0.10ns, scaled from
-      # sky130hd by FO4 logic-switching ratio (1.4ns / 14x). That anchor was
-      # wrong -- bitline/sense-amp access time is bitcell/array-dominated, not
-      # logic-gate-switching-dominated, so it doesn't scale with FO4 the way
-      # a logic path does (the "SRAM scaling wall": memory timing scales much
-      # slower across nodes than logic speed). Re-anchored to asap7's own
-      # measured 0.2183ns instead -- gt2n and asap7 are both leading-edge
-      # finFET/GAAFET nodes with comparable bitcell physics, so gt2n's access
-      # time should be close to, not a further-scaled-down multiple of,
-      # asap7's. All other values still order-of-magnitude estimates.
-      2: dict(
-        access_time_ns=0.200, cycle_time_ns=0.075,
-        standby_leakage_per_bank_mW=0.10, fo4_ps=5.0,
-        pin_dynamic_power_mW=0.001,
-      ),
     }
     if process.tech_nm in TECH_ANALYTIC:
+      assert process.tech_nm in TECH_BITCELL_UM, (
+        f"tech_nm={process.tech_nm} has an analytical timing entry in "
+        f"TECH_ANALYTIC but no bitcell entry in TECH_BITCELL_UM (area.py) -- "
+        f"add one, or get_macro_dimensions() will silently fall back to "
+        f"requiring fin_pitch_nm/contacted_poly_pitch_nm instead."
+      )
       self.tech_node_nm  = process.tech_nm
       self.associativity = 1
       for k, v in TECH_ANALYTIC[process.tech_nm].items():
@@ -170,7 +179,11 @@ class Memory:
 
       
     
-    self.cap_input_pf = 0.005
+    # nangate45 (CACTI path, below) has no override yet -- set it there under
+    # a tech_nm==45 check before this line, not by adding a key to
+    # TECH_ANALYTIC, which would also divert it off the CACTI path entirely.
+    if not hasattr(self, 'cap_input_pf'):  # blanket default; gt2n sets its own above
+      self.cap_input_pf = 0.005
 
     self.tech_node_um = self.tech_node_nm / 1000.0
 
@@ -183,8 +196,10 @@ class Memory:
 
     #self.pin_dynamic_power_mW = (0.5 * self.cap_input_pf * (float(self.process.voltage)**2))*1e9 ;# P = 0.5*CV^2
   
-    self.t_setup_ns = 0.050  ;# arbitrary 50ps setup
-    self.t_hold_ns  = 0.050  ;# arbitrary 50ps hold
+    if not hasattr(self, 't_setup_ns'):  # blanket default; gt2n sets its own above
+      self.t_setup_ns = 0.050  ;# arbitrary 50ps setup
+    if not hasattr(self, 't_hold_ns'):  # blanket default; gt2n sets its own above
+      self.t_hold_ns  = 0.050  ;# arbitrary 50ps hold
 
   # __run_cacti: shell out to cacti to generate a csv file with more data
   # regarding this memory based on the input parameters from the json

--- a/scripts/utils/class_process.py
+++ b/scripts/utils/class_process.py
@@ -47,9 +47,10 @@ class Process:
     self.snapWidth_nm   = int(json_data['snapWidth_nm']) if 'snapWidth_nm' in json_data else 1
     self.snapHeight_nm  = int(json_data['snapHeight_nm']) if 'snapHeight_nm' in json_data else 1
     self.flipPins       = str(json_data['flipPins']) if 'flipPins' in json_data else 'false'
-    # Explicit layer overrides for LR and TB pins (overrides flipPins layer logic)
+    # Explicit layer overrides for LR, TB, and supply (PS) pins (overrides flipPins layer logic)
     self.LRpinLayer     = str(json_data['LRpinLayer']) if 'LRpinLayer' in json_data else ''
     self.TBpinLayer     = str(json_data['TBpinLayer']) if 'TBpinLayer' in json_data else ''
+    self.PSpinLayer     = str(json_data['PSpinLayer']) if 'PSpinLayer' in json_data else ''
     
     self.vlogTimingCheckSignalExpansion = bool(json_data['vlogTimingCheckSignalExpansion']) if 'vlogTimingCheckSignalExpansion' in json_data else False
 

--- a/scripts/utils/class_process.py
+++ b/scripts/utils/class_process.py
@@ -47,6 +47,9 @@ class Process:
     self.snapWidth_nm   = int(json_data['snapWidth_nm']) if 'snapWidth_nm' in json_data else 1
     self.snapHeight_nm  = int(json_data['snapHeight_nm']) if 'snapHeight_nm' in json_data else 1
     self.flipPins       = str(json_data['flipPins']) if 'flipPins' in json_data else 'false'
+    # Explicit layer overrides for LR and TB pins (overrides flipPins layer logic)
+    self.LRpinLayer     = str(json_data['LRpinLayer']) if 'LRpinLayer' in json_data else ''
+    self.TBpinLayer     = str(json_data['TBpinLayer']) if 'TBpinLayer' in json_data else ''
     
     self.vlogTimingCheckSignalExpansion = bool(json_data['vlogTimingCheckSignalExpansion']) if 'vlogTimingCheckSignalExpansion' in json_data else False
 

--- a/scripts/utils/generate_lef.py
+++ b/scripts/utils/generate_lef.py
@@ -58,7 +58,7 @@ def generate_lef( mem ):
     metalPrefix    = mem.process.metalPrefix
     flip           = mem.process.flipPins.lower() == 'true'
     pin_height = mem.process.LRheight_um
-    supply_pin_layer = '%s4' % metalPrefix
+    supply_pin_layer = mem.process.PSpinLayer if mem.process.PSpinLayer else '%s4' % metalPrefix
     
     #########################################
     # Calculate pin spacing (pitch) AND split pins around the four sides of the macro.

--- a/scripts/utils/generate_lef.py
+++ b/scripts/utils/generate_lef.py
@@ -305,10 +305,14 @@ def lef_add_pin(fid, mem, pin_name, is_input, side, cursor, pitch):
     layer = mem.process.metalPrefix + ('3' if mem.process.flipPins.lower() == 'true' else '4')
     if (side == 'T' or side == 'B'):
         # Switch layers for preferred direction based on top/bottom pins
-        layer = mem.process.metalPrefix + '2' if layer == mem.process.metalPrefix + '3' else mem.process.metalPrefix + '3' 
+        layer = mem.process.metalPrefix + '2' if layer == mem.process.metalPrefix + '3' else mem.process.metalPrefix + '3'
+        if mem.process.TBpinLayer:
+            layer = mem.process.TBpinLayer
         pw  = mem.process.TBwidth_um
         ph  = mem.process.TBheight_um
     else:
+        if mem.process.LRpinLayer:
+            layer = mem.process.LRpinLayer
         pw  = mem.process.LRwidth_um
         ph  = mem.process.LRheight_um
     


### PR DESCRIPTION
## Summary
- Adds tech_nm=2 (gt2n, 2nm GAAFET) support to the per-tech analytical
  bitcell/timing path (area.py, class_memory.py), alongside
  asap7/sky130hd.
- Adds an explicit per-side pin-layer override (class_process.py,
  generate_lef.py) for platforms whose L/R and T/B pin layers can't
  be derived from the flipPins heuristic (gt2n places L/R pins on
  M2, T/B on M3).
- Bitcell area uses TSMC's disclosed 2nm-class (N2) figure
  (~0.021 um^2, corroborated by Intel's 18A RibbonFET at the same
  figure), split at asap7's bitcell aspect ratio (2.5) since no
  published width x height could be found for either.
- access_time_ns is approximated as ~10% faster than asap7's value
  (0.2183ns -> 0.200ns).

Used by HighTide's gt2n fakeram generation, validated via designs
utilizing the generated macros in a full RTL-to-GDSII flow.